### PR TITLE
Feature/mc message formatting

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.5+build.1
 loader_version=0.16.14
 
 # Mod Properties
-mod_version=2.0.0
+mod_version=2.1.0
 maven_group=com.blocketing
 archives_base_name=blocketing
 

--- a/src/main/java/com/blocketing/Blocketing.java
+++ b/src/main/java/com/blocketing/Blocketing.java
@@ -1,5 +1,6 @@
 package com.blocketing;
 
+import com.blocketing.commands.ConfigurationCommand;
 import com.blocketing.discord.JdaDiscordBot;
 import com.blocketing.events.MinecraftChatHandler;
 import com.blocketing.events.PlayerEventHandler;

--- a/src/main/java/com/blocketing/commands/ConfigurationCommand.java
+++ b/src/main/java/com/blocketing/commands/ConfigurationCommand.java
@@ -1,4 +1,4 @@
-package com.blocketing;
+package com.blocketing.commands;
 
 import com.blocketing.config.ConfigLoader;
 import com.blocketing.events.MinecraftChatHandler;

--- a/src/main/java/com/blocketing/discord/JdaMessageListener.java
+++ b/src/main/java/com/blocketing/discord/JdaMessageListener.java
@@ -4,7 +4,7 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import com.blocketing.config.ConfigLoader;
 import com.blocketing.Blocketing;
-import com.blocketing.events.MinecraftChatHandler;
+import com.blocketing.utils.ColorUtil;
 import net.minecraft.server.MinecraftServer;
 
 /**
@@ -29,7 +29,36 @@ public class JdaMessageListener extends ListenerAdapter {
         if (server != null) {
             String username = event.getAuthor().getName();
             String content = event.getMessage().getContentDisplay();
-            MinecraftChatHandler.sendMessageToAllPlayers(server, username, content);
+
+            // Get top role color
+            java.awt.Color roleColor = null;
+            if (event.getMember() != null && event.getMember().getColor() != null) {
+                roleColor = event.getMember().getColor();
+            }
+            net.minecraft.util.Formatting mcRoleColor = com.blocketing.utils.ColorUtil.getNearestFormatting(roleColor);
+
+            // Build formatted message
+            net.minecraft.text.Text prefix = net.minecraft.text.Text.literal("[")
+                    .styled(style -> style.withColor(net.minecraft.util.Formatting.BLUE))
+                    .append(net.minecraft.text.Text.literal("Discord")
+                            .styled(style -> style.withColor(net.minecraft.util.Formatting.BLUE).withBold(true)))
+                    .append(net.minecraft.text.Text.literal("] ")
+                            .styled(style -> style.withColor(net.minecraft.util.Formatting.BLUE)));
+
+            net.minecraft.text.Text user = net.minecraft.text.Text.literal("<" + username + ">")
+                    .styled(style -> style.withColor(mcRoleColor));
+
+            net.minecraft.text.Text msg = net.minecraft.text.Text.literal(" " + content)
+                    .styled(style -> style.withColor(net.minecraft.util.Formatting.WHITE));
+
+            net.minecraft.text.Text full = net.minecraft.text.Text.empty()
+                    .append(prefix)
+                    .append(user)
+                    .append(msg);
+
+            for (net.minecraft.server.network.ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+                player.sendMessage(full, false);
+            }
         }
     }
 }

--- a/src/main/java/com/blocketing/utils/ColorUtil.java
+++ b/src/main/java/com/blocketing/utils/ColorUtil.java
@@ -1,0 +1,41 @@
+package com.blocketing.utils;
+
+import net.minecraft.util.Formatting;
+
+import java.awt.*;
+
+/**
+ * Utility class for color-related operations in the Blocketing mod.
+ * Provides methods to find the nearest Minecraft formatting color to a given AWT Color.
+ */
+public class ColorUtil {
+
+    /**
+     * Finds the nearest Minecraft formatting color to the given AWT Color.
+     *
+     * @param color The AWT Color to find the nearest formatting for.
+     * @return The nearest Formatting color, or Formatting.WHITE if the input is null.
+     */
+    public static Formatting getNearestFormatting(Color color) {
+        if (color == null) return Formatting.WHITE;
+        Formatting closest = Formatting.WHITE;
+        double minDist = Double.MAX_VALUE;
+        for (Formatting formatting : Formatting.values()) {
+            if (!formatting.isColor()) continue;
+            Color mcColor = new Color(formatting.getColorValue(), true);
+            double dist = colorDistance(color, mcColor);
+            if (dist < minDist) {
+                minDist = dist;
+                closest = formatting;
+            }
+        }
+        return closest;
+    }
+
+    private static double colorDistance(Color c1, Color c2) {
+        int r = c1.getRed() - c2.getRed();
+        int g = c1.getGreen() - c2.getGreen();
+        int b = c1.getBlue() - c2.getBlue();
+        return r * r + g * g + b * b;
+    }
+}


### PR DESCRIPTION
This pull request introduces several enhancements to the Blocketing mod, including version updates, improved message formatting in Discord-to-Minecraft communication, and the addition of a utility class for color mapping. The changes aim to improve user experience and code organization.

### Version Update:
* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L12-R12): Updated `mod_version` from `2.0.0` to `2.1.0` to reflect the new features and improvements.

### Code Organization:
* [`src/main/java/com/blocketing/commands/ConfigurationCommand.java`](diffhunk://#diff-288b79155fabfa3cfa9f0267ff76b7cd2cf4db6e9ac18c305310be100b1180dcL1-R1): Renamed the `ConfigurationCommand` class to reside in the `commands` package for better organization.
* [`src/main/java/com/blocketing/Blocketing.java`](diffhunk://#diff-a4c59e8a78374c76b582286c17261def23beae0c121f091472cde8ff59f5c5b8R3): Updated imports to include the newly relocated `ConfigurationCommand` class.

### Feature Enhancements:
* [`src/main/java/com/blocketing/discord/JdaMessageListener.java`](diffhunk://#diff-be59b0e5141427e0faf332301d69fba0daed2cd78062029e0ae6252a47491502L32-R61): Improved Discord-to-Minecraft message formatting by adding role-based color mapping and styled text formatting. This enhances the visual presentation of messages sent from Discord to Minecraft.

### Utility Addition:
* [`src/main/java/com/blocketing/utils/ColorUtil.java`](diffhunk://#diff-13944ea4626c02f6acc36470ee299572f4d4c47519ba7cd7b0fb63c3ae6f58cdR1-R41): Added a new utility class to map AWT colors to the nearest Minecraft formatting colors, enabling role-based color representation in messages.