### PR TITLE
Add reload command to restart Discord bot alongside config reload

### DIFF
--- a/src/main/java/com/blocketing/commands/ConfigurationCommand.java
+++ b/src/main/java/com/blocketing/commands/ConfigurationCommand.java
@@ -1,6 +1,7 @@
 package com.blocketing.commands;
 
 import com.blocketing.config.ConfigLoader;
+import com.blocketing.discord.JdaDiscordBot;
 import com.blocketing.events.MinecraftChatHandler;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
@@ -130,7 +131,8 @@ public class ConfigurationCommand {
                 .then(CommandManager.literal("reload")
                         .executes(context -> {
                             ConfigLoader.reloadConfig();
-                            context.getSource().sendFeedback(() -> Text.of("Blocketing config reloaded."), true);
+                            JdaDiscordBot.restart();
+                            context.getSource().sendFeedback(() -> Text.of("Blocketing config and Discord bot reloaded."), true);
                             return 1;
                         })
                 )

--- a/src/main/java/com/blocketing/discord/JdaDiscordBot.java
+++ b/src/main/java/com/blocketing/discord/JdaDiscordBot.java
@@ -114,6 +114,24 @@ public class JdaDiscordBot {
     }
 
     /**
+     * Gets the JDA instance for interacting with Discord.
+     *
+     * @return The JDA instance, or null if not initialized.
+     */
+    public static void stop() {
+        if (jda != null) {
+            jda.shutdownNow();
+            jda = null;
+            LOGGER.info("JDA Discord Bot stopped.");
+        }
+    }
+
+    public static void restart() {
+        stop();
+        start();
+    }
+
+    /**
      * Checks if the given string is a valid Discord snowflake ID.
      *
      * @param id The string to check.


### PR DESCRIPTION
This pull request introduces functionality to manage the lifecycle of the Discord bot (`JdaDiscordBot`) and integrates it into the configuration reload command. The changes streamline the bot's operation by adding methods to stop and restart it, ensuring the bot can be reloaded alongside the configuration.

### Integration of Discord bot lifecycle management:

* [`src/main/java/com/blocketing/commands/ConfigurationCommand.java`](diffhunk://#diff-288b79155fabfa3cfa9f0267ff76b7cd2cf4db6e9ac18c305310be100b1180dcL133-R135): Updated the `reload` command to restart the Discord bot (`JdaDiscordBot.restart()`) when reloading the configuration. The feedback message was updated to reflect both configuration and bot reloads.

### New methods for Discord bot lifecycle:

* [`src/main/java/com/blocketing/discord/JdaDiscordBot.java`](diffhunk://#diff-0d8c0491d0cfc3991b6fe6a97a90d0d521caabf150613f73e941ab3bcb5eb425R116-R133): Added `stop()` method to shut down the Discord bot and set its instance to `null`. Logged the shutdown process for better traceability.
* [`src/main/java/com/blocketing/discord/JdaDiscordBot.java`](diffhunk://#diff-0d8c0491d0cfc3991b6fe6a97a90d0d521caabf150613f73e941ab3bcb5eb425R116-R133): Added `restart()` method to stop and then start the bot, enabling seamless restarts.

### Dependency addition:

* [`src/main/java/com/blocketing/commands/ConfigurationCommand.java`](diffhunk://#diff-288b79155fabfa3cfa9f0267ff76b7cd2cf4db6e9ac18c305310be100b1180dcR4): Imported `JdaDiscordBot` to enable bot lifecycle management within the configuration command.