### PR TITLE
Feature/update checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 > /blocketing toggle advancements   # Toggle the sending of advancements to Discord.
 > /blocketing toggle deaths   # Toggle the sending of death messages to Discord.
 > /blocketing toggle player_chat_mode   # Toggle player chat via Discord webhook (player name/avatar in Discord).
+> /blocketing toggle update-info   # Toggle update notifications.
 > ```
 
 ### ♻️ Reload Config

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.6+build.1
 loader_version=0.16.14
 
 # Mod Properties
-mod_version=2.2.1
+mod_version=2.3.0
 maven_group=com.blocketing
 archives_base_name=blocketing
 

--- a/src/main/java/com/blocketing/Blocketing.java
+++ b/src/main/java/com/blocketing/Blocketing.java
@@ -4,6 +4,7 @@ import com.blocketing.commands.ConfigurationCommand;
 import com.blocketing.discord.JdaDiscordBot;
 import com.blocketing.events.MinecraftChatHandler;
 import com.blocketing.events.PlayerEventHandler;
+import com.blocketing.utils.UpdateChecker;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -56,6 +57,7 @@ public class Blocketing implements ModInitializer {
 		LOGGER.info("Server has started.");
 		minecraftServer = server;
 		MinecraftChatHandler.sendServerStartMessage(minecraftServer.getServerMotd()); // Sends a server start message to the Discord-Bot
+		UpdateChecker.checkForUpdateAndNotifyDiscord(server);
 	}
 
 	/**

--- a/src/main/java/com/blocketing/commands/ConfigurationCommand.java
+++ b/src/main/java/com/blocketing/commands/ConfigurationCommand.java
@@ -123,6 +123,14 @@ public class ConfigurationCommand {
                                     return 1;
                                 })
                         )
+                        .then(CommandManager.literal("update-info")
+                                .executes(context -> {
+                                    boolean enabled = !ConfigLoader.getBooleanProperty("UPDATE_INFO_ENABLED", true);
+                                    ConfigLoader.setProperty("UPDATE_INFO_ENABLED", String.valueOf(enabled));
+                                    context.getSource().sendFeedback(() -> Text.of("Update info notifications are now " + (enabled ? "enabled" : "disabled") + "."), true);
+                                    return 1;
+                                })
+                        )
                         .executes(context -> {
                             context.getSource().sendFeedback(() -> Text.of("Available toggles: advancements, deaths, player_chat_mode"), true);
                             return 1;

--- a/src/main/java/com/blocketing/commands/ConfigurationCommand.java
+++ b/src/main/java/com/blocketing/commands/ConfigurationCommand.java
@@ -132,7 +132,7 @@ public class ConfigurationCommand {
                                 })
                         )
                         .executes(context -> {
-                            context.getSource().sendFeedback(() -> Text.of("Available toggles: advancements, deaths, player_chat_mode"), true);
+                            context.getSource().sendFeedback(() -> Text.of("Available toggles: advancements, deaths, player_chat_mode, update-info"), true);
                             return 1;
                         })
                 )

--- a/src/main/java/com/blocketing/events/MinecraftChatHandler.java
+++ b/src/main/java/com/blocketing/events/MinecraftChatHandler.java
@@ -67,7 +67,7 @@ public class MinecraftChatHandler {
      */
     public static void sendServerStartMessage(String serverName) {
         String placeholderUrl = "https://example.com/placeholder.png";
-        JdaDiscordBot.sendEmbedToDiscord("Server Started", "The Minecraft server **" + serverName + "** has started.", 0x800080, placeholderUrl); // Purple colored embed
+        JdaDiscordBot.sendEmbedToDiscord("Server Started", "The Minecraft server **" + serverName + "** has started.", 0x800080, placeholderUrl); // Purple-colored embed
     }
 
     /**
@@ -75,7 +75,7 @@ public class MinecraftChatHandler {
      */
     public static void sendServerStopMessage() {
         String placeholderUrl = "https://example.com/placeholder.png";
-        JdaDiscordBot.sendEmbedToDiscord("Server Stopped", "The Minecraft server has stopped.", 0x40E0D0, placeholderUrl); // Turquoise colored embed
+        JdaDiscordBot.sendEmbedToDiscord("Server Stopped", "The Minecraft server has stopped.", 0x40E0D0, placeholderUrl); // Turquoise-colored embed
     }
 
     /**
@@ -136,7 +136,7 @@ public class MinecraftChatHandler {
         String playerName = message.substring(0, playerNameEndIndex).trim();
         String deathMessage = message.substring(playerNameEndIndex).trim();
         String formattedMessage = "**" + playerName + "** " + deathMessage;
-        JdaDiscordBot.sendEmbedToDiscord("💀 Player Death", formattedMessage, 0x000000, null);
+        JdaDiscordBot.sendEmbedToDiscord("💀 Player Death", formattedMessage, 0x000000, null); // Black-colored embed
     }
 
     /**
@@ -180,7 +180,7 @@ public class MinecraftChatHandler {
         }
 
         String formattedMessage = "**" + playerName + "** has unlocked **" + advancement + "**!";
-        JdaDiscordBot.sendEmbedToDiscord(title, formattedMessage, 0x77DD77, null);
+        JdaDiscordBot.sendEmbedToDiscord(title, formattedMessage, 0x77DD77, null); // Pastel-green-colored embed
     }
 
     /**

--- a/src/main/java/com/blocketing/events/MinecraftChatHandler.java
+++ b/src/main/java/com/blocketing/events/MinecraftChatHandler.java
@@ -63,18 +63,6 @@ public class MinecraftChatHandler {
     }
 
     /**
-     * Sends a message to all players in the Minecraft chat.
-     * @param minecraftServer The Minecraft server.
-     * @param username The username to mention in the message.
-     * @param content The content of the message.
-     */
-    public static void sendMessageToAllPlayers(MinecraftServer minecraftServer, String username, String content) {
-        for (ServerPlayerEntity player : minecraftServer.getPlayerManager().getPlayerList()) {
-            player.sendMessage(Text.of("<@DC_" + username + "> " + content), false);
-        }
-    }
-
-    /**
      * Sends a message to Discord-Bot when the server starts.
      */
     public static void sendServerStartMessage(String serverName) {

--- a/src/main/java/com/blocketing/events/PlayerEventHandler.java
+++ b/src/main/java/com/blocketing/events/PlayerEventHandler.java
@@ -7,7 +7,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 
 /**
- * This class would be responsible for handling player events like join and disconnect events.
+ * This class is responsible for handling player events like join and disconnect events.
  */
 public class PlayerEventHandler {
 

--- a/src/main/java/com/blocketing/events/PlayerEventHandler.java
+++ b/src/main/java/com/blocketing/events/PlayerEventHandler.java
@@ -1,6 +1,7 @@
 package com.blocketing.events;
 
 import com.blocketing.discord.JdaDiscordBot;
+import com.blocketing.utils.UpdateChecker;
 import net.fabricmc.fabric.api.networking.v1.PacketSender;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.minecraft.server.MinecraftServer;
@@ -28,6 +29,8 @@ public class PlayerEventHandler {
         String avatarUrl = "https://api.mineatar.io/face/" + playerUUID + "?scale=8"; // Get the player's avatar    (scale= (4=mini, 8=normal, 12=big))
 
         JdaDiscordBot.sendEmbedToDiscord("Player Joined", "**" + playerName + "** joined the server.", 0x00FF00, avatarUrl); // Green-colored embed
+
+        UpdateChecker.checkForUpdateAndNotifyOperator(handler.getPlayer());
     }
 
     /**

--- a/src/main/java/com/blocketing/events/PlayerEventHandler.java
+++ b/src/main/java/com/blocketing/events/PlayerEventHandler.java
@@ -27,7 +27,7 @@ public class PlayerEventHandler {
         String playerUUID = handler.getPlayer().getUuid().toString();
         String avatarUrl = "https://api.mineatar.io/face/" + playerUUID + "?scale=8"; // Get the player's avatar    (scale= (4=mini, 8=normal, 12=big))
 
-        JdaDiscordBot.sendEmbedToDiscord("Player Joined", "**" + playerName + "** joined the server.", 0x00FF00, avatarUrl); // Green colored embed
+        JdaDiscordBot.sendEmbedToDiscord("Player Joined", "**" + playerName + "** joined the server.", 0x00FF00, avatarUrl); // Green-colored embed
     }
 
     /**
@@ -40,6 +40,6 @@ public class PlayerEventHandler {
         String playerUUID = handler.getPlayer().getUuid().toString();
         String avatarUrl = "https://api.mineatar.io/face/" + playerUUID + "?scale=8"; // Get the player's avatar    (scale= (4=mini, 8=normal, 12=big))
 
-        JdaDiscordBot.sendEmbedToDiscord("Player Left", "**" + playerName + "** left the server.", 0xFF0000, avatarUrl); // Red colored embed
+        JdaDiscordBot.sendEmbedToDiscord("Player Left", "**" + playerName + "** left the server.", 0xFF0000, avatarUrl); // Red-colored embed
     }
 }

--- a/src/main/java/com/blocketing/utils/UpdateChecker.java
+++ b/src/main/java/com/blocketing/utils/UpdateChecker.java
@@ -1,0 +1,77 @@
+package com.blocketing.utils;
+
+import com.blocketing.config.ConfigLoader;
+import com.blocketing.discord.JdaDiscordBot;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+/**
+ * This class is responsible for checking for updates of the Blocketing mod
+ * and notifying operators and Discord about available updates.
+ */
+public class UpdateChecker {
+    private static final Logger LOGGER = LoggerFactory.getLogger("Blocketing|UpdateChecker");
+    private static final String GITHUB_API_URL = "https://api.github.com/repos/crunnna/blocketing-fabric-mod/releases/latest";
+    private static final String CHANGELOG_URL = "https://github.com/crunnna/blocketing-fabric-mod/releases/latest";
+
+
+    /**
+     * Checks for the latest version of the Blocketing mod and notifies Discord if an update is available.
+     *
+     * @param server The Minecraft server instance.
+     */
+    public static void checkForUpdateAndNotifyDiscord(MinecraftServer server) {
+        if (!ConfigLoader.getBooleanProperty("UPDATE_INFO_ENABLED", true)) return;
+        String latest = fetchLatestVersion();
+        String current = ConfigLoader.getProperty("mod_version");
+        if (latest != null && !latest.equals(current)) {
+            String msg = "A new Blocketing version (" + latest + ") is available! See the changelog: " + CHANGELOG_URL;
+            JdaDiscordBot.sendEmbedToDiscord("Update Available", msg, 0xFF0000, null);
+        }
+    }
+
+    /**
+     * Checks for the latest version of the Blocketing mod and notifies operators if an update is available.
+     *
+     * @param player The player who has permission to check for updates.
+     */
+    public static void checkForUpdateAndNotifyOperator(ServerPlayerEntity player) {
+        if (player.hasPermissionLevel(4) && com.blocketing.config.ConfigLoader.getBooleanProperty("UPDATE_INFO_ENABLED", true)) {
+            String latest = fetchLatestVersion();
+            String current = ConfigLoader.getProperty("mod_version");
+            if (latest != null && !latest.equals(current)) {
+                String msg = "A new Blocketing version (" + latest + ") is available! See the changelog: " + CHANGELOG_URL;
+                player.sendMessage(Text.of(msg), false);
+                player.sendMessage(Text.of("Tip: Use /blocketing toggle update-info to enable/disable this notification."), false);
+            }
+        }
+    }
+
+    /**
+     * Checks for the latest version of the Blocketing mod on GitHub.
+     *
+     * @return The latest version as a String, or null if an error occurs.
+     */
+    private static String fetchLatestVersion() {
+        try {
+            HttpURLConnection conn = (HttpURLConnection) new URL(GITHUB_API_URL).openConnection();
+            conn.setRequestProperty("Accept", "application/vnd.github+json");
+            Scanner scanner = new Scanner(conn.getInputStream());
+            StringBuilder json = new StringBuilder();
+            while (scanner.hasNext()) json.append(scanner.nextLine());
+            scanner.close();
+            String tag = json.toString().split("\"tag_name\":\"")[1].split("\"")[0];
+            return tag.replaceFirst("^v", "");
+        } catch (Exception e) {
+            LOGGER.warn("Could not check for updates", e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/blocketing/utils/UpdateChecker.java
+++ b/src/main/java/com/blocketing/utils/UpdateChecker.java
@@ -36,8 +36,15 @@ public class UpdateChecker {
         String latest = fetchLatestVersion();
         String current = ConfigLoader.getProperty("mod_version");
         if (latest != null && !latest.equals(current)) {
-            String msg = "A new Blocketing version (" + latest + ") is available! See the changelog: " + CHANGELOG_URL;
-            JdaDiscordBot.sendEmbedToDiscord("Update Available", msg, 0xFF0000, null);
+            String msg = "**A new Blocketing version (`"+ latest +"`) is available!**\n"
+                    + "[View Changelog](https://github.com/crunnna/blocketing-fabric-mod/releases/latest)";
+            String logoUrl = "https://raw.githubusercontent.com/crunnna/blocketing-fabric-mod/main/src/main/resources/assets/blocketing/icon.png";
+            JdaDiscordBot.sendEmbedToDiscord(
+                    "\uD83C\uDD95 Update Available",
+                    msg,
+                    0xFF0000,
+                    logoUrl // Only thumbnail supported
+            );
         }
     }
 


### PR DESCRIPTION
This pull request introduces a new update notification feature for the Blocketing mod, alongside a version bump and minor code improvements. The update notification system informs both Discord and server operators about new mod versions. Additionally, some redundant methods were removed, and minor text adjustments were made to improve clarity.

### New Update Notification System:
* Added a new `/blocketing toggle update-info` command to enable or disable update notifications.
* Introduced the `UpdateChecker` utility class to fetch the latest version from GitHub and notify Discord and server operators about updates.
* Integrated update checks into the server start event and player join event for operators.

### Version Update:
* Updated the mod version from `2.2.1` to `2.3.0` in `gradle.properties`

### Code Cleanup and Text Adjustments:
* Removed the unused `sendMessageToAllPlayers` method from `MinecraftChatHandler`.
* Standardized embed color comments for consistency (e.g., "Green-colored embed").