### PR TITLE
Bugfix/update checker fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.6+build.1
 loader_version=0.16.14
 
 # Mod Properties
-mod_version=2.3.0
+mod_version=2.3.1
 maven_group=com.blocketing
 archives_base_name=blocketing
 

--- a/src/main/java/com/blocketing/utils/UpdateChecker.java
+++ b/src/main/java/com/blocketing/utils/UpdateChecker.java
@@ -33,9 +33,9 @@ public class UpdateChecker {
      */
     public static void checkForUpdateAndNotifyDiscord(MinecraftServer server) {
         if (!ConfigLoader.getBooleanProperty("UPDATE_INFO_ENABLED", true)) return;
-        String latest = fetchLatestVersion();
-        String current = ConfigLoader.getProperty("mod_version");
-        if (latest != null && !latest.equals(current)) {
+        String latest = normalizeVersion(fetchLatestVersion());
+        String current = normalizeVersion(ConfigLoader.getProperty("mod_version"));
+        if (latest != null && current != null && !latest.equals(current)) {
             String msg = "**A new Blocketing version (`"+ latest +"`) is available!**\n"
                     + "[View Changelog](https://github.com/crunnna/blocketing-fabric-mod/releases/latest)";
             String logoUrl = "https://raw.githubusercontent.com/crunnna/blocketing-fabric-mod/main/src/main/resources/assets/blocketing/icon.png";
@@ -43,7 +43,7 @@ public class UpdateChecker {
                     "\uD83C\uDD95 Update Available",
                     msg,
                     0xFF0000,
-                    logoUrl // Only thumbnail supported
+                    logoUrl
             );
         }
     }
@@ -60,9 +60,9 @@ public class UpdateChecker {
             return;
         }
 
-        String latest = fetchLatestVersion();
-        String current = ConfigLoader.getProperty("mod_version");
-        if (latest != null && !latest.equals(current)) {
+        String latest = normalizeVersion(fetchLatestVersion());
+        String current = normalizeVersion(ConfigLoader.getProperty("mod_version"));
+        if (latest != null && current != null && !latest.equals(current)) {
 
             Text prefix = Text.literal("[Blocketing] ")
                     .setStyle(Style.EMPTY.withColor(Formatting.RED).withBold(true));
@@ -116,10 +116,21 @@ public class UpdateChecker {
             while (scanner.hasNext()) json.append(scanner.nextLine());
             scanner.close();
             String tag = json.toString().split("\"tag_name\":\"")[1].split("\"")[0];
-            return tag.replaceFirst("^v", "");
+            return tag.trim();
         } catch (Exception e) {
             LOGGER.warn("Could not check for updates", e);
             return null;
         }
+    }
+
+    /**
+     * Normalizes the version string by removing leading 'v' and trimming whitespace.
+     *
+     * @param version The version string to normalize.
+     * @return The normalized version string, or null if the input is null.
+     */
+    private static String normalizeVersion(String version) {
+        if (version == null) return null;
+        return version.trim().replaceFirst("^v", "");
     }
 }


### PR DESCRIPTION
This pull request improves the update-checking logic in the `UpdateChecker` utility class. The most significant changes include the introduction of a new `normalizeVersion` method for consistent version string handling, updates to the `fetchLatestVersion` method, and modifications to how version comparisons are performed.

### Version Management Updates:

* Updated the `mod_version` in `gradle.properties` from `2.3.0` to `2.3.1`.

### Code Enhancements in `UpdateChecker`:

* Introduced a new `normalizeVersion` method to standardize version strings by removing leading 'v' and trimming whitespace. This ensures consistency when comparing versions.
* Updated the `fetchLatestVersion` method to trim whitespace from the fetched version string, improving its reliability.
* Modified the `checkForUpdateAndNotifyDiscord` and `checkForUpdateAndNotifyOperator` methods to use the `normalizeVersion` method for both the current and latest version strings, ensuring accurate comparisons.