### PR TITLE
Feature/multi server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 - ✅ In-game configuration via commands 🎮
 - ✅ Update notifications for new mod versions 🔔
 - ✅ Paginated player list and server status via Discord slash commands 📊
+- ✅ Multi-server support to run multiple Minecraft server instances using the same Discord bot token (per-server channel filtering) ♾️
 ---
 
 ## 🚀 Installation

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ maven_group=com.blocketing
 archives_base_name=blocketing
 
 # Dependencies
-fabric_version=0.135.0+1.21.10
+fabric_version=0.136.0+1.21.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.10+build.2
 loader_version=0.17.3
 
 # Mod Properties
-mod_version=2.5.3
+mod_version=2.6.0
 maven_group=com.blocketing
 archives_base_name=blocketing
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.10+build.2
 loader_version=0.17.3
 
 # Mod Properties
-mod_version=2.5.2
+mod_version=2.5.3
 maven_group=com.blocketing
 archives_base_name=blocketing
 

--- a/src/main/java/com/blocketing/discord/JdaDiscordBot.java
+++ b/src/main/java/com/blocketing/discord/JdaDiscordBot.java
@@ -75,6 +75,7 @@ public class JdaDiscordBot {
 
     /**
      * Sends a plain text message to the configured Discord channel.
+     * Uses a single CHANNEL_ID from configuration.
      *
      * @param message The message to send.
      */
@@ -84,20 +85,25 @@ public class JdaDiscordBot {
             LOGGER.warn("JDA is not initialized. Cannot send message to Discord.");
             return;
         }
-        if (isValidSnowflake(channelId)) {
-            final var channel = jda.getTextChannelById(channelId);
-            if (channel != null) {
-                channel.sendMessage(message).queue();
-            } else {
-                LOGGER.warn("Discord channel not found for ID: {}", channelId);
-            }
-        } else {
+        if (channelId == null || channelId.isBlank()) {
+            LOGGER.warn("CHANNEL_ID is not configured. Cannot send message to Discord.");
+            return;
+        }
+        if (isInvalidSnowflake(channelId)) {
             LOGGER.warn("Invalid Discord channel ID: {}", channelId);
+            return;
+        }
+        final var channel = jda.getTextChannelById(channelId);
+        if (channel != null) {
+            channel.sendMessage(message).queue();
+        } else {
+            LOGGER.warn("Discord channel not found for ID: {}", channelId);
         }
     }
 
     /**
      * Sends an embed message to the configured Discord channel.
+     * Uses a single CHANNEL_ID from configuration.
      *
      * @param title       The title of the embed.
      * @param description The description of the embed.
@@ -110,13 +116,12 @@ public class JdaDiscordBot {
             LOGGER.warn("JDA is not initialized. Cannot send embed to Discord.");
             return;
         }
-        if (!isValidSnowflake(channelId)) {
-            LOGGER.warn("Invalid Discord channel ID: {}", channelId);
+        if (channelId == null || channelId.isBlank()) {
+            LOGGER.warn("CHANNEL_ID is not configured. Cannot send embed to Discord.");
             return;
         }
-        final MessageChannel channel = jda.getChannelById(MessageChannel.class, channelId);
-        if (channel == null) {
-            LOGGER.warn("Discord channel not found for ID: {}", channelId);
+        if (isInvalidSnowflake(channelId)) {
+            LOGGER.warn("Invalid Discord channel ID: {}", channelId);
             return;
         }
 
@@ -127,6 +132,12 @@ public class JdaDiscordBot {
                 .setTimestamp(Instant.now());
         if (avatarUrl != null && !avatarUrl.isBlank()) {
             embed.setThumbnail(avatarUrl);
+        }
+
+        final MessageChannel channel = jda.getChannelById(MessageChannel.class, channelId);
+        if (channel == null) {
+            LOGGER.warn("Discord channel not found for ID: {}", channelId);
+            return;
         }
         channel.sendMessageEmbeds(embed.build()).queue();
     }
@@ -152,12 +163,12 @@ public class JdaDiscordBot {
     }
 
     /**
-     * Checks if the given string is a valid Discord snowflake ID.
+     * Validates if the given ID is a valid Discord snowflake.
      *
-     * @param id The string to check.
-     * @return True if the string is a valid snowflake ID, false otherwise.
+     * @param id The ID to validate.
+     * @return true if the ID is invalid, false otherwise.
      */
-    private static boolean isValidSnowflake(String id) {
-        return id != null && id.matches("\\d{17,20}");
+    private static boolean isInvalidSnowflake(String id) {
+        return id == null || !id.matches("\\d{17,20}");
     }
 }

--- a/src/main/java/com/blocketing/discord/JdaDiscordBot.java
+++ b/src/main/java/com/blocketing/discord/JdaDiscordBot.java
@@ -51,6 +51,26 @@ public class JdaDiscordBot {
     }
 
     /**
+     * Gets the JDA instance for interacting with Discord.
+     */
+    public static void stop() {
+        if (jda != null) {
+            jda.shutdownNow();
+            jda = null;
+            LOGGER.info("JDA Discord Bot stopped.");
+        }
+    }
+
+    /**
+     * Restarts the JDA Discord Bot.
+     * This will stop the current instance and start a new one.
+     */
+    public static void restart() {
+        stop();
+        start();
+    }
+
+    /**
      * Registers slash commands for the Discord bot in the specified guild.
      *
      * @param guildId The ID of the guild where the commands should be registered.
@@ -140,26 +160,6 @@ public class JdaDiscordBot {
             return;
         }
         channel.sendMessageEmbeds(embed.build()).queue();
-    }
-
-    /**
-     * Gets the JDA instance for interacting with Discord.
-     */
-    public static void stop() {
-        if (jda != null) {
-            jda.shutdownNow();
-            jda = null;
-            LOGGER.info("JDA Discord Bot stopped.");
-        }
-    }
-
-    /**
-     * Restarts the JDA Discord Bot.
-     * This will stop the current instance and start a new one.
-     */
-    public static void restart() {
-        stop();
-        start();
     }
 
     /**

--- a/src/main/java/com/blocketing/discord/listener/JdaCommandListener.java
+++ b/src/main/java/com/blocketing/discord/listener/JdaCommandListener.java
@@ -3,26 +3,39 @@ package com.blocketing.discord.listener;
 import com.blocketing.discord.commands.ConsoleCommandHandler;
 import com.blocketing.discord.commands.PlayersCommandHandler;
 import com.blocketing.discord.commands.StatusCommandHandler;
+import com.blocketing.config.ConfigLoader;
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class listens for Discord slash commands and button interactions,
  * and delegates them to the appropriate command handlers.
  */
 public class JdaCommandListener extends ListenerAdapter {
+    private static final Logger LOGGER = LoggerFactory.getLogger("Blocketing|Discord|JdaCommandListener");
+
     private final ConsoleCommandHandler consoleHandler = new ConsoleCommandHandler();
     private final StatusCommandHandler statusHandler = new StatusCommandHandler();
     private final PlayersCommandHandler playersHandler = new PlayersCommandHandler();
 
     /**
      * Handles incoming slash command interactions from Discord.
+     * Commands are only delegated if the interaction happened in the configured channel.
      *
      * @param event The slash command interaction event.
      */
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        final MessageChannelUnion eventChannel = event.getChannel();
+        if (isNotInConfiguredChannel(eventChannel)) {
+            LOGGER.debug("Ignored slash command '{}' from non-configured channel", event.getName());
+            return;
+        }
+
         switch (event.getName()) {
             case "console", "command" -> consoleHandler.handle(event);
             case "status" -> statusHandler.handle(event);
@@ -32,11 +45,35 @@ public class JdaCommandListener extends ListenerAdapter {
 
     /**
      * Handles button interactions for paginated player lists.
+     * Button events are also restricted to the configured channel to avoid cross-server handling.
      *
      * @param event The button interaction event.
      */
     @Override
     public void onButtonInteraction(ButtonInteractionEvent event) {
+        final MessageChannelUnion eventChannel = event.getChannel();
+        if (isNotInConfiguredChannel(eventChannel)) {
+            LOGGER.debug("Ignored button interaction '{}' from non-configured channel", event.getComponentId());
+            return;
+        }
         playersHandler.handleButton(event);
+    }
+
+    /**
+     * Checks if the given channel is not the one configured for bot interactions.
+     *
+     * @param channel The channel to check.
+     * @return true if the channel is not the configured one, false otherwise.
+     */
+    private boolean isNotInConfiguredChannel(MessageChannelUnion channel) {
+        final String configured = ConfigLoader.getProperty("CHANNEL_ID");
+        if (channel == null) return true; // treat null channel as 'not configured'
+        if (configured == null || configured.isBlank()) return true; // no configured channel -> treat as not configured
+        try {
+            return !channel.getId().equals(configured);
+        } catch (Exception e) {
+            LOGGER.debug("Failed to compare channel IDs", e);
+            return true;
+        }
     }
 }

--- a/src/main/java/com/blocketing/discord/listener/JdaMessageListener.java
+++ b/src/main/java/com/blocketing/discord/listener/JdaMessageListener.java
@@ -26,8 +26,10 @@ public class JdaMessageListener extends ListenerAdapter {
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
         if (event.getAuthor().isBot()) return; // Ignore messages from bots
-        String channelId = ConfigLoader.getProperty("CHANNEL_ID");
-        if (!event.getChannel().getId().equals(channelId)) return; // Check if the message is in the configured channel
+        String channelCfg = ConfigLoader.getProperty("CHANNEL_ID");
+        if (channelCfg == null || channelCfg.isBlank()) return;
+        final String eventChannelId = event.getChannel().getId();
+        if (!eventChannelId.equals(channelCfg)) return; // Check if the message is in the configured channel
         if (!event.getMessage().getAttachments().isEmpty() || !event.getMessage().getEmbeds().isEmpty()) return; // Ignore messages with attachments or embeds
 
         // Log Discord-Message to console if enabled


### PR DESCRIPTION
This pull request introduces multi-server support and improves the reliability and safety of Discord channel handling throughout the codebase.

**Multi-server support and channel filtering:**

* Added multi-server support, allowing the bot to run multiple Minecraft server instances with the same Discord bot token and per-server channel filtering.
* All Discord command and message handlers now strictly check that interactions only occur in the configured channel, preventing cross-server command handling and accidental message leakage.

**Dependency and version updates:**

* Updated mod version to `2.6.0` and bumped the Fabric loader and API versions for compatibility with the latest Minecraft release.